### PR TITLE
Update PowerTheVSAN.psm1

### DIFF
--- a/PowerTheVSAN.psm1
+++ b/PowerTheVSAN.psm1
@@ -23,12 +23,17 @@ Function Get-VSANObjectHealth {
       [switch]$UseCachedInfo
       ,
       [Parameter(Mandatory = $false)]
-      [switch]$HealthyOnly    
+      [switch]$HealthyOnly
+      ,
+      [Parameter(Mandatory = $false)]
+      [ValidateSet("defaultView", "deployAssist")]
+      [string]$VsanHealthPerspective = "defaultView"
     )
   
     Begin {
-      $vchs = Get-VsanView -Id "VsanVcClusterHealthSystem-vsan-cluster-health-system"
-      $VsanVersion = (Get-VsanView -Id "VsanVcClusterHealthSystem-vsan-cluster-health-system").VsanVcClusterQueryVerifyHealthSystemVersions((Get-Cluster).Id) | select VcVersion
+      $vcName = $vsancluster.Uid.Split("@")[1].Split(":")[0]
+      $vchs = Get-VsanView -Id "VsanVcClusterHealthSystem-vsan-cluster-health-system" -Server $vcName
+      $VsanVersion = (Get-VsanView -Id "VsanVcClusterHealthSystem-vsan-cluster-health-system" -Server $vcName).VsanVcClusterQueryVerifyHealthSystemVersions(($VsanCluster).Id) | select VcVersion
     }
   
     Process {
@@ -47,8 +52,22 @@ Function Get-VSANObjectHealth {
           }
         }
       }
-      elseif ($VsanCluster.VsanEnabled -and $VsanVersion.VcVersion -lt '6.6') {
-          Write-Warning -Message 'vSAN cluster is currently at a version newer than this call allows. Please open an issue: https://github.com/mitsumaui/PowerTheVSAN/issues'
+      elseif ($VsanCluster.VsanEnabled -and $VsanVersion.VcVersion -gt '6.6') {
+        $result = $vchs.VsanQueryVcClusterHealthSummary($VsanCluster.id, $null, $null, $ShowObjectUUIDs, $null, $UseCachedInfo, $VsanHealthPerspective)
+        if ($result) {
+            if ($HealthyOnly) {
+                $Health = $result.ObjectHealth.ObjectHealthDetail | Where-Object {$_.Health -notlike 'healthy' -and $_.NumObjects -gt 0}
+                if ($Health) {
+                    return $false
+                }
+                else {
+                    return $true
+                }
+            }
+            else {
+                return $result.ObjectHealth.ObjectHealthDetail
+            }
+        } 
       }
     }
   }


### PR DESCRIPTION
Adding support for VSAN 6.6, filtering the view to the cluster's vCenter, and getting the vsan version referencing the given cluster rather than querying all clusters.